### PR TITLE
Add support for functions, chaining, etc

### DIFF
--- a/lib/rules/sort.js
+++ b/lib/rules/sort.js
@@ -21,6 +21,25 @@ function isDependencyArrayHook(node) {
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
     create(context) {
+        function getSortableNameFromNode(node) {
+            if (!node) return '';
+
+            switch (node.type) {
+                case 'Identifier':
+                    return node.name;
+                case 'MemberExpression':
+                    // For chained expressions, e.g., `a.b.c`, we'll return `a.b.c`
+                    return (
+                        getSortableNameFromNode(node.object) +
+                        '.' +
+                        getSortableNameFromNode(node.property)
+                    );
+                default:
+                    // For any other types or for simplicity, you could just stringify the node.
+                    return context.getSourceCode().getText(node);
+            }
+        }
+
         return {
             CallExpression(node) {
                 if (isDependencyArrayHook(node.callee)) {
@@ -33,12 +52,19 @@ module.exports = {
                     ) {
                         const currentDependencies = [...dependencies.elements];
                         const currentNames = currentDependencies.map(
-                            (item) => item.name
+                            getSortableNameFromNode
                         );
 
-                        const sortedDependencies = [
-                            ...dependencies.elements,
-                        ].sort((a, b) => (a.name < b.name ? -1 : 1));
+                        const sortedDependencies = [...dependencies.elements]
+                            .map((n) => ({
+                                ...n,
+                                name: getSortableNameFromNode(n),
+                            }))
+                            .sort((a, b) =>
+                                a.name
+                                    .toLowerCase()
+                                    .localeCompare(b.name.toLowerCase())
+                            );
                         const sortedNames = sortedDependencies.map(
                             (item) => item.name
                         );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eslint-plugin-sort-react-dependency-arrays",
     "description": "ESLint plugin to alphabetically sort React hook dependency arrays",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "author": "Steven Sacks <stevensacks@gmail.com>",
     "keywords": [
         "eslint",


### PR DESCRIPTION
Dependencies such as `JSON.stringify(foo)` and `bar?.baz` were being replaced by `undefined` in the array. This fixes that problem.